### PR TITLE
Remove stubs from phpstan.neon

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,5 +3,3 @@ parameters:
     paths:
         - src/
         - tests/
-    stubFiles:
-    		- vendor/php-stubs/wordpress-stubs/wordpress-stubs.php


### PR DESCRIPTION
The phpstan-wordpress extension includes those stubs.
