### PR TITLE
chore(deps): adopt area:* labels and trim dead dependabot ignores

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,23 +17,12 @@ updates:
       day: monday
     open-pull-requests-limit: 10
     labels:
-      - dependencies
+      - area:tooling
     groups:
       dev-dependencies:
         dependency-type: development
         patterns:
           - "*"
-    ignore:
-      # respect/validation 3.x requires PHP 8.5 — hold at ^2.x while we target 8.4.
-      - dependency-name: "respect/validation"
-        update-types: ["version-update:semver-major"]
-      # thecodingmachine/safe 3.x — held: packages don't build green on this major
-      # yet. Revisit when the code is adapted to the v3 API / the PHP floor rises.
-      - dependency-name: "thecodingmachine/safe"
-        update-types: ["version-update:semver-major"]
-      # jjgrainger/posttypes 3.x — held: the wrapper isn't updated for v3 yet.
-      - dependency-name: "jjgrainger/posttypes"
-        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: github-actions
     directory: "/"
@@ -41,8 +30,7 @@ updates:
       interval: weekly
       day: monday
     labels:
-      - dependencies
-      - github-actions
+      - area:ci
     groups:
       github-actions:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,8 @@
 # weekly PR to cut noise (a fresh config otherwise opens one PR per action per
 # repo). Production (runtime) composer deps get individual PRs because they affect
 # downstream consumers and warrant review. Production majors that don't build
-# green yet are held under `ignore` (below) — drop the entry once the package
-# builds on that major.
+# green yet are a deliberate per-package choice: add an `ignore:` entry under
+# the composer ecosystem when needed.
 
 version: 2
 updates:


### PR DESCRIPTION
Brings this repo's `dependabot.yml` to the org canonical (config only — no code changes).

## Changes
- bump-PR labels → org `area:*` taxonomy (composer dev-deps → `area:tooling`, GitHub Actions → `area:ci`)
- removed `ignore:` holds for dependencies this repo doesn't declare; live holds (and any `ignore:` block) are otherwise preserved

## Why
- `dependencies`/`github-actions` aren't in the org label taxonomy and were never created, so Dependabot reported "labels could not be found" on every bump PR. The `area:*` labels are now seeded in every repo, and the scaffold baseline is fixed for new seeds (kaisekidev/kaiseki-scaffold-module#7).
- Blanket `ignore:` holds inherited from the old canonical are trimmed to only the dependents that declare them. Part of kaisekidev/kaiseki-org#47.

## Validation
- Targeted edit; result validated as YAML. Live `ignore:` holds preserved. Standard CI runs on this PR and must pass before it merges.